### PR TITLE
style: add card components for commit types in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,6 +80,30 @@
             color: #00cec9;
             border-bottom: 2px solid #00cec9;
         }
-        body {
-            padding-top: 70px;
+
+
+        .card-row {
+            display: flex;
+            gap: 2rem;
+            margin-top: 3rem;
+            justify-content: center;
+        }
+        .card {
+            padding: 2rem 2.5rem;
+            border-radius: 12px;
+            color: #fff;
+            font-size: 1.3rem;
+            font-weight: bold;
+            box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+            min-width: 160px;
+            text-align: center;
+        }
+        .card-commit {
+            background: #27ae60;
+        }
+        .card-feature {
+            background: #f39c12;
+        }
+        .card-broke {
+            background: #e74c3c;
         }


### PR DESCRIPTION
Introduce new card-row and card classes to style commit type
cards with distinct colors, padding, and layout. This improves
visual grouping and clarity for commit categories such as commit,
feature, and broke. Remove unused body padding to clean up styles.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #9 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #8 
- <kbd>&nbsp;1&nbsp;</kbd> #7 
<!-- GitButler Footer Boundary Bottom -->

