### PR TITLE
fix(nav): update menu link from Features to About page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
             <h1>GitButler</h1>
             <nav class="menu">
                 <a href="#" class="menu-item">Home</a>
-                <a href="#" class="menu-item">Features</a>
+                <a href="./about.html" class="menu-item">About</a>
                 <a href="#" class="menu-item">Docs</a>
                 <a href="#" class="menu-item">Contact</a>
             </nav>


### PR DESCRIPTION
Change the navigation menu item from "Features" to "About" and update
the link to point to the about.html page. This improves site navigation
by directing users to the relevant About section instead of a placeholder.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #11 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #10 
<!-- GitButler Footer Boundary Bottom -->

